### PR TITLE
Fixed formatting issue that caused CachedFingerprinted to throw.

### DIFF
--- a/src/ServiceWorker/Files/CacheFingerprinted.js
+++ b/src/ServiceWorker/Files/CacheFingerprinted.js
@@ -11,7 +11,7 @@
             .then(function (cache) {
                 return cache.addAll([
                     offlineUrl,
-                    { routes }
+                    {routes}
                 ]);
             });
     }


### PR DESCRIPTION
Visual Studio reformatted when I pasted, breaking our poor man's templating, thus causing a runtime error and busting CacheFingerprinted.