### PR TITLE
Update CacheFirstSafe.js

### DIFF
--- a/src/ServiceWorker/Files/CacheFirstSafe.js
+++ b/src/ServiceWorker/Files/CacheFirstSafe.js
@@ -17,7 +17,7 @@
     }
 
     function addToCache(request, response) {
-        if (!response.ok)
+        if (!response.ok && response.type !== 'opaque')
             return;
 
         var copy = response.clone();


### PR DESCRIPTION
When retrieving certain files (i.e images on an Azure container), the response is of type "opaque" so not accessible from javascript for exemple (So the reponse.ok is false), but being able to cache that response to use later is still very usefull. It is the all point of no-cors requests.
https://jakearchibald.com/2015/thats-so-fetch/
