### PR TITLE
Service Worker not registering in production environment #14 - SSL of…

### DIFF
--- a/src/PwaOptions.cs
+++ b/src/PwaOptions.cs
@@ -106,5 +106,10 @@ namespace WebEssentials.AspNetCore.Pwa
         /// Determines whether a CSP nonce will be added via NWebSec
         /// </summary>
         public bool EnableCspNonce { get; set; }
+        
+        /// <summary>
+        /// Generate code even on HTTP connection. Necessary for SSL offloading.
+        /// </summary>
+        public bool AllowHttp { get; set; }
     }
 }

--- a/src/ServiceWorker/ServiceWorkerTagHelperComponent.cs
+++ b/src/ServiceWorker/ServiceWorkerTagHelperComponent.cs
@@ -35,7 +35,7 @@ namespace WebEssentials.AspNetCore.Pwa
 
             if (string.Equals(context.TagName, "body", StringComparison.OrdinalIgnoreCase))
             {
-                if (_accessor.HttpContext.Request.IsHttps || _env.IsDevelopment())
+                if ((_options.AllowHttp || _accessor.HttpContext.Request.IsHttps) || _env.IsDevelopment())
                 {
                     output.PostContent.AppendHtml(_script);
                 }


### PR DESCRIPTION
Added option `AllowHttp` which allow emitting service worker HTML code even when not on the HTTPS connection. Useful for SSL offloading.