### PR TITLE
Added support for CustomStrategy and Added IgnoreRoutes Option.

### DIFF
--- a/README.md
+++ b/README.md
@@ -263,6 +263,32 @@ This strategy will always try the network first for all resources and then fall 
 
 This strategy is completely safe to use and is primarily useful for offline-only scenarios since it isn't giving any performance benefits.
 
+### CustomStrategy
+This strategy will allow the user to specify their own implementation as a Javascript(.js) file.  By default the app will search for a file named `customserviceworker.js` in the wwwroot folder.   
+A filename may be explicitly set by providing it as an option when registering the service in the `Startup.cs` or `appsettings.json` file.
+
+```C#
+public void ConfigureServices(IServiceCollection services)
+        {
+            services.AddMvc();
+            services.AddProgressiveWebApp(new PwaOptions { RegisterServiceWorker = true, Strategy = ServiceWorkerStrategy.CustomStrategy, CustomServiceWorkerStrategyFileName = "myCustomServiceworkerStrategy.js"});
+        }
+```
+
+When creating the `customserviceworker.js` by providing {version}, {routes}, {ignoreRoutes} and {offlineRoute} values within the javascript file string, interpolation will be used to replace these values with option values as set in the `Startup.cs` or `appsettings.json` file.
+
+```javascript
+(function () {
+    //Insert Your Service Worker In place of this one!
+
+    // Update 'version' if you need to refresh the cache
+    var version = '{version}';
+    var offlineUrl = "{offlineRoute}";
+    var routes = "{routes}";
+    var routesToIgnore = "{ignoreRoutes}";
+});
+```
+
 ## .Net Core Application hosted as Virtual Directory
 You can now specify a specific BaseURL if you plan to host your application as a Virtual Directory in IIS:
 

--- a/sample/Startup.cs
+++ b/sample/Startup.cs
@@ -30,7 +30,8 @@ namespace Sample
             {
                 app.UseBrowserLink();
             }
-                app.UseDeveloperExceptionPage();
+
+            app.UseDeveloperExceptionPage();
 
             app.UseStaticFiles();
             app.UseMvcWithDefaultRoute();

--- a/sample/wwwroot/customserviceworker.js
+++ b/sample/wwwroot/customserviceworker.js
@@ -1,0 +1,9 @@
+﻿(function () {
+    //Insert Your Service Worker In place of this one!
+
+    // Update 'version' if you need to refresh the cache
+    var version = '{version}';
+    var offlineUrl = "{offlineRoute}";
+    var routes = "{routes}";
+    var routesToIgnore = "{ignoreRoutes}";
+});

--- a/src/Constants.cs
+++ b/src/Constants.cs
@@ -3,6 +3,7 @@
     internal class Constants
     {
         public const string ServiceworkerRoute = "/serviceworker";
+        public const string CustomServiceworkerFileName = "customserviceworker.js";
         public const string Offlineroute = "/offline.html";
         public const string DefaultCacheId = "v1.0";
         public const string WebManifestRoute = "/manifest.webmanifest";

--- a/src/PwaController.cs
+++ b/src/PwaController.cs
@@ -2,8 +2,10 @@
 using System.IO;
 using System.Linq;
 using System.Reflection;
+using System.Security.Cryptography.X509Certificates;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Mvc;
+using Microsoft.CodeAnalysis.Semantics;
 using Microsoft.Net.Http.Headers;
 
 namespace WebEssentials.AspNetCore.Pwa
@@ -14,13 +16,15 @@ namespace WebEssentials.AspNetCore.Pwa
     public class PwaController : Controller
     {
         private readonly PwaOptions _options;
+        private readonly RetrieveCustomServiceworker _customServiceworker;
 
         /// <summary>
         /// Creates an instance of the controller.
         /// </summary>
-        public PwaController(PwaOptions options)
+        public PwaController(PwaOptions options, RetrieveCustomServiceworker customServiceworker)
         {
             _options = options;
+            _customServiceworker = customServiceworker;
         }
 
         /// <summary>
@@ -32,20 +36,33 @@ namespace WebEssentials.AspNetCore.Pwa
             Response.ContentType = "application/javascript; charset=utf-8";
             Response.Headers[HeaderNames.CacheControl] = $"max-age={_options.ServiceWorkerCacheControlMaxAge}";
 
-            string fileName = _options.Strategy + ".js";
-            Assembly assembly = typeof(PwaController).Assembly;
-            Stream resourceStream = assembly.GetManifestResourceStream($"WebEssentials.AspNetCore.Pwa.ServiceWorker.Files.{fileName}");
-
-            using (var reader = new StreamReader(resourceStream))
+            if (_options.Strategy == ServiceWorkerStrategy.CustomStrategy)
             {
-                string js = await reader.ReadToEndAsync();
-                string modified = js
-                    .Replace("{version}", _options.CacheId + "::" + _options.Strategy)
-                    .Replace("{routes}", string.Join(",", _options.RoutesToPreCache.Split(new[] { ',' }, StringSplitOptions.RemoveEmptyEntries).Select(r => "'" + r.Trim() + "'")))
-                    .Replace("{offlineRoute}", _options.BaseRoute + _options.OfflineRoute);
-
-                return Content(modified);
+                string js = _customServiceworker.GetCustomServiceworker(_options.CustomServiceWorkerStrategyFileName);
+                return Content(InsertStrategyOptions(js)); 
             }
+
+            else
+            {
+                string fileName = _options.Strategy + ".js";
+                Assembly assembly = typeof(PwaController).Assembly;
+                Stream resourceStream = assembly.GetManifestResourceStream($"WebEssentials.AspNetCore.Pwa.ServiceWorker.Files.{fileName}");
+
+                using (var reader = new StreamReader(resourceStream))
+                {
+                    string js = await reader.ReadToEndAsync();
+                    return Content(InsertStrategyOptions(js));
+                }
+            }
+        }
+
+        private string InsertStrategyOptions(string javascriptString)
+        {
+            return javascriptString
+                .Replace("{version}", _options.CacheId + "::" + _options.Strategy)
+                .Replace("{routes}", string.Join(",", _options.RoutesToPreCache.Split(new[] { ',' }, StringSplitOptions.RemoveEmptyEntries).Select(r => "'" + r.Trim() + "'")))
+                .Replace("{offlineRoute}", _options.BaseRoute + _options.OfflineRoute)
+                .Replace("{ignoreRoutes}", string.Join(",", _options.RoutesToIgnore.Split(new[] { ',' }, StringSplitOptions.RemoveEmptyEntries).Select(r => "'" + r.Trim() + "'")));
         }
 
         /// <summary>

--- a/src/PwaOptions.cs
+++ b/src/PwaOptions.cs
@@ -23,6 +23,8 @@ namespace WebEssentials.AspNetCore.Pwa
             EnableCspNonce = false;
             ServiceWorkerCacheControlMaxAge = 60 * 60 * 24 * 30;    // 30 days
             WebManifestCacheControlMaxAge = 60 * 60 * 24 * 30;      // 30 days
+            CustomServiceWorkerStrategyFileName = Constants.CustomServiceworkerFileName;
+            RoutesToIgnore = "";
         }
 
         internal PwaOptions(IConfiguration config)
@@ -32,6 +34,9 @@ namespace WebEssentials.AspNetCore.Pwa
             RoutesToPreCache = config["pwa:routesToPreCache"] ?? RoutesToPreCache;
             BaseRoute = config["pwa:baseRoute"] ?? BaseRoute;
             OfflineRoute = config["pwa:offlineRoute"] ?? OfflineRoute;
+            RoutesToIgnore = config["pwa:routesToIgnore"] ?? RoutesToIgnore;
+            CustomServiceWorkerStrategyFileName =
+                config["pwa:customServiceWorkerFileName"] ?? CustomServiceWorkerStrategyFileName;
 
             if (bool.TryParse(config["pwa:registerServiceWorker"] ?? "true", out bool register))
             {
@@ -118,5 +123,15 @@ namespace WebEssentials.AspNetCore.Pwa
         /// Generate code even on HTTP connection. Necessary for SSL offloading.
         /// </summary>
         public bool AllowHttp { get; set; }
+
+        /// <summary>
+        /// The file name of the Custom ServiceWorker Strategy
+        /// </summary>
+        public string CustomServiceWorkerStrategyFileName { get; set; }
+
+        /// <summary>
+        /// A comma separated list of routes to ignore when implementing a CustomServiceworker.  
+        /// </summary>
+        public string RoutesToIgnore { get; set; }
     }
 }

--- a/src/RetrieveCustomServiceworker.cs
+++ b/src/RetrieveCustomServiceworker.cs
@@ -1,0 +1,33 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Text;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.Extensions.Caching.Memory;
+using Microsoft.Extensions.FileProviders;
+
+namespace WebEssentials.AspNetCore.Pwa
+{
+    /// <summary>
+    /// A utility that can retrieve the contents of a CustomServiceworker strategy file
+    /// </summary>
+    public class RetrieveCustomServiceworker
+    {
+        private readonly IHostingEnvironment _env;
+
+        public RetrieveCustomServiceworker(IHostingEnvironment env)
+        {
+            _env = env;
+        }
+        
+        /// <summary>
+        /// Returns a <seealso cref="string"/> containing the contents of a Custom Serviceworker javascript file
+        /// </summary>
+        /// <returns></returns>
+        public string GetCustomServiceworker(string fileName = "customserviceworker.js")
+        {
+            IFileInfo file = _env.WebRootFileProvider.GetFileInfo(fileName);
+            return File.ReadAllText(file.PhysicalPath);
+        }
+    }
+}

--- a/src/ServiceCollectionExtensions.cs
+++ b/src/ServiceCollectionExtensions.cs
@@ -19,6 +19,7 @@ namespace Microsoft.Extensions.DependencyInjection
         {
             services.TryAddSingleton<IHttpContextAccessor, HttpContextAccessor>();
             services.AddTransient<ITagHelperComponent, ServiceWorkerTagHelperComponent>();
+            services.AddTransient<RetrieveCustomServiceworker>();
             services.AddTransient(svc => new PwaOptions(svc.GetRequiredService<IConfiguration>()));
 
             return services;
@@ -31,6 +32,7 @@ namespace Microsoft.Extensions.DependencyInjection
         {
             services.TryAddSingleton<IHttpContextAccessor, HttpContextAccessor>();
             services.AddTransient<ITagHelperComponent, ServiceWorkerTagHelperComponent>();
+            services.AddTransient<RetrieveCustomServiceworker>();
             services.AddTransient(factory => options);
 
             return services;
@@ -39,10 +41,11 @@ namespace Microsoft.Extensions.DependencyInjection
         /// <summary>
         /// Adds ServiceWorker services to the specified <see cref="IServiceCollection"/>.
         /// </summary>
-        public static IServiceCollection AddServiceWorker(this IServiceCollection services, string baseRoute = "", string offlineRoute = Constants.Offlineroute, ServiceWorkerStrategy strategy = ServiceWorkerStrategy.CacheFirstSafe, bool registerServiceWorker = true, bool registerWebManifest = true, string cacheId = Constants.DefaultCacheId, string routesToPreCache = "")
+        public static IServiceCollection AddServiceWorker(this IServiceCollection services, string baseRoute = "", string offlineRoute = Constants.Offlineroute, ServiceWorkerStrategy strategy = ServiceWorkerStrategy.CacheFirstSafe, bool registerServiceWorker = true, bool registerWebManifest = true, string cacheId = Constants.DefaultCacheId, string routesToPreCache = "", string routesToIgnore ="", string customServiceWorkerFileName = Constants.CustomServiceworkerFileName)
         {
             services.TryAddSingleton<IHttpContextAccessor, HttpContextAccessor>();
             services.AddTransient<ITagHelperComponent, ServiceWorkerTagHelperComponent>();
+            services.AddTransient<RetrieveCustomServiceworker>();
             services.AddTransient(factory => new PwaOptions
             {
                 BaseRoute = baseRoute,
@@ -51,7 +54,9 @@ namespace Microsoft.Extensions.DependencyInjection
                 RegisterServiceWorker = registerServiceWorker,
                 RegisterWebmanifest = registerWebManifest,
                 CacheId = cacheId,
-                RoutesToPreCache = routesToPreCache
+                RoutesToPreCache = routesToPreCache,
+                CustomServiceWorkerStrategyFileName = customServiceWorkerFileName,
+                RoutesToIgnore = routesToIgnore
             });
 
             return services;
@@ -61,7 +66,7 @@ namespace Microsoft.Extensions.DependencyInjection
         /// Adds Web App Manifest services to the specified <see cref="IServiceCollection"/>.
         /// </summary>
         /// <param name="services">The service collection.</param>
-        /// <param name="manifestFileName">The path to the Web App Manifest file relative to the wwwroot rolder.</param>
+        /// <param name="manifestFileName">The path to the Web App Manifest file relative to the wwwroot folder.</param>
         public static IServiceCollection AddWebManifest(this IServiceCollection services, string manifestFileName = Constants.WebManifestFileName)
         {
             services.AddTransient<ITagHelperComponent, WebmanifestTagHelperComponent>();
@@ -81,7 +86,7 @@ namespace Microsoft.Extensions.DependencyInjection
         /// Adds Web App Manifest and Service Worker to the specified <see cref="IServiceCollection"/>.
         /// </summary>
         /// <param name="services">The service collection.</param>
-        /// <param name="manifestFileName">The path to the Web App Manifest file relative to the wwwroot rolder.</param>
+        /// <param name="manifestFileName">The path to the Web App Manifest file relative to the wwwroot folder.</param>
         public static IServiceCollection AddProgressiveWebApp(this IServiceCollection services, string manifestFileName = Constants.WebManifestFileName)
         {
             return services.AddWebManifest(manifestFileName)
@@ -92,7 +97,7 @@ namespace Microsoft.Extensions.DependencyInjection
         /// Adds Web App Manifest and Service Worker to the specified <see cref="IServiceCollection"/>.
         /// </summary>
         /// <param name="services">The service collection.</param>
-        /// <param name="manifestFileName">The path to the Web App Manifest file relative to the wwwroot rolder.</param>
+        /// <param name="manifestFileName">The path to the Web App Manifest file relative to the wwwroot folder.</param>
         /// <param name="options">Options for the service worker and Web App Manifest</param>
         public static IServiceCollection AddProgressiveWebApp(this IServiceCollection services, PwaOptions options, string manifestFileName = Constants.WebManifestFileName)
         {

--- a/src/ServiceWorker/ServiceWorkerStrategy.cs
+++ b/src/ServiceWorker/ServiceWorkerStrategy.cs
@@ -29,6 +29,11 @@
         /// <summary>
         /// Always tries the network first and falls back to cache when offline.
         /// </summary>
-        NetworkFirst
+        NetworkFirst,
+
+        /// <summary>
+        /// Allows a user defined custom strategy to be provided.
+        /// </summary>
+        CustomStrategy
     }
 }


### PR DESCRIPTION
Hi Mads and Team,
I have added in support for a CustomStrategy.
This strategy is user defined through a customserviceworker.js file and allows users to create the file and supply whatever behaviour they desire.  
I implemented this as I have noticed many requests to add various features to the different caching strategies and thought that this would be a more manageable alternative.

I have also added in a IgnoreRoutes option that allows users to define a list of routes that they dont want cached or want to treat differently.  Please note that I have not changed any of the existing strategies, I have only supplied the option so that it can be used in the CustomStrategy and potentially in future updates if this behaviour should need to be added to a new caching strategy etc in fututre.  

Please let me know if there are any issues or changes you would like to see!

Regards
Alex

N.B - The Json schema is out of date (it is missing a few of the newer features) and needs to be updated to reflect this.  (currently it throws validation errors however they can be ignored as you know)


