### PR TITLE
Remove dependency to "NWebsec.AspNetCore.Mvc.TagHelpers" (#94)

### DIFF
--- a/src/WebEssentials.AspNetCore.Pwa.csproj
+++ b/src/WebEssentials.AspNetCore.Pwa.csproj
@@ -43,7 +43,6 @@
     <PackageReference Include="Microsoft.AspNetCore.Razor.Runtime" Version="2.0.3" />
     <PackageReference Include="Microsoft.Extensions.Configuration" Version="2.0.2" />
     <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="2.0.2" />
-    <PackageReference Include="NWebsec.AspNetCore.Mvc.TagHelpers" Version="2.0.0" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
Remove dependency to "NWebsec.AspNetCore.Mvc.TagHelpers" to fix #94 Remove dependency to "NWebsec.AspNetCore.Mvc.TagHelpers" 