### PR TITLE
#97 Use Package Reference to simplify packages

### DIFF
--- a/src/PwaController.cs
+++ b/src/PwaController.cs
@@ -5,7 +5,6 @@ using System.Reflection;
 using System.Security.Cryptography.X509Certificates;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Mvc;
-using Microsoft.CodeAnalysis.Semantics;
 using Microsoft.Net.Http.Headers;
 
 namespace WebEssentials.AspNetCore.Pwa
@@ -40,7 +39,7 @@ namespace WebEssentials.AspNetCore.Pwa
             if (_options.Strategy == ServiceWorkerStrategy.CustomStrategy)
             {
                 string js = _customServiceworker.GetCustomServiceworker(_options.CustomServiceWorkerStrategyFileName);
-                return Content(InsertStrategyOptions(js)); 
+                return Content(InsertStrategyOptions(js));
             }
 
             else

--- a/src/WebEssentials.AspNetCore.Pwa.csproj
+++ b/src/WebEssentials.AspNetCore.Pwa.csproj
@@ -36,10 +36,9 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.Configuration" Version="2.0.2" />
-    <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="2.0.2" />
+    <PackageReference Include="Newtonsoft.Json" Version="10.0.1" />
   </ItemGroup>
-  
+
   <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0'">
     <PackageReference Include="Microsoft.AspNetCore.Mvc" version="2.0.4" />
     <PackageReference Include="Microsoft.AspNetCore.Hosting.Abstractions" Version="2.0.3" />
@@ -50,7 +49,6 @@
 
   <ItemGroup Condition="'$(TargetFramework)' != 'netstandard2.0'">
     <FrameworkReference Include="Microsoft.AspNetCore.App" />
-    <PackageReference Include="Newtonsoft.Json" Version="10.0.1" />
   </ItemGroup>
 
 </Project>

--- a/src/WebEssentials.AspNetCore.Pwa.csproj
+++ b/src/WebEssentials.AspNetCore.Pwa.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netstandard2.0</TargetFramework>
+    <TargetFrameworks>netstandard2.0;netcoreapp3.0</TargetFrameworks>
     <DocumentationFile>bin\$(Configuration)\$(TargetFramework)\WebEssentials.AspNetCore.Pwa.xml</DocumentationFile>
     <GeneratePackageOnBuild>True</GeneratePackageOnBuild>
     <PackageTags>asp.net, performance, speed, cache, caching</PackageTags>
@@ -36,13 +36,21 @@
   </ItemGroup>
 
   <ItemGroup>
+    <PackageReference Include="Microsoft.Extensions.Configuration" Version="2.0.2" />
+    <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="2.0.2" />
+  </ItemGroup>
+  
+  <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0'">
     <PackageReference Include="Microsoft.AspNetCore.Mvc" version="2.0.4" />
     <PackageReference Include="Microsoft.AspNetCore.Hosting.Abstractions" Version="2.0.3" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Abstractions" Version="2.0.4" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.TagHelpers" Version="2.0.4" />
     <PackageReference Include="Microsoft.AspNetCore.Razor.Runtime" Version="2.0.3" />
-    <PackageReference Include="Microsoft.Extensions.Configuration" Version="2.0.2" />
-    <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="2.0.2" />
+  </ItemGroup>
+
+  <ItemGroup Condition="'$(TargetFramework)' != 'netstandard2.0'">
+    <FrameworkReference Include="Microsoft.AspNetCore.App" />
+    <PackageReference Include="Newtonsoft.Json" Version="10.0.1" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
The Package now targets netstandard2.0 & netcoreapp3.0. Each framework has different dependencies with the main difference being netcoreapp 3.0 use a framework reference to eliminates the need for all of the existing packages but has had to add a non transitant reference for newtonsoft.